### PR TITLE
corecting sqrt(a) in pecular velocity

### DIFF
--- a/src/lytomo_watershed/fgpa.py
+++ b/src/lytomo_watershed/fgpa.py
@@ -238,7 +238,8 @@ def get_tau_conv(comm, z, savedir='density_highres/', savefile='FGPA_flux_z2.4.h
                     # Peculiar velocity addition
                     ind = np.where((dens != 0))
                     vel_pec = np.zeros_like(f['DM/pz'][ic,jc,:])
-                    vel_pec[ind] = f['DM/pz'][ic,jc,:][ind]/(dens[ind]*np.sqrt(1+z))
+                    # Convert momentum to velocity
+                    vel_pec[ind] = f['DM/pz'][ic,jc,:][ind]/dens[ind]
                     vel_pec = gaussian_filter1d(vel_pec, SmLV)
                     dens = gaussian_filter1d(dens, SmLD)
                     u0 = up + vel_pec

--- a/src/lytomo_watershed/get_density_field.py
+++ b/src/lytomo_watershed/get_density_field.py
@@ -47,14 +47,14 @@ def TNG(snaps='/lustre/scratch/mqezlou/TNG300-1/output/snapdir_029/snap_029.*', 
            if zspace :
               ## peculiar velocity correction
               # Old Dask used in nbodykit does not accept elemnt-wise assignment, so we need to project V_pec along z 
-              cat['Coordinates'] = (cat['Coordinates'] + (1000*cosmo.h/(cosmo.H(z).value*(1+z)**0.5))*cat['Velocities']*[0,0,1])%boxsize
+              cat['Coordinates'] = (cat['Coordinates'] + (1000*cosmo.h*np.sqrt(1+z)/cosmo.H(z).value)*cat['Velocities']*[0,0,1])%boxsize
 
            print('Rank ', comm.rank, ' cat,size= ', cat.size, flush=True)
            mesh = cat.to_mesh(Nmesh=Nmesh, position='Coordinates')
            dens = mesh.compute()
            if momentumz :
               # Average line-of-sight velocity in each voxel
-              cat['Vz'] = cat['Velocities'][:,2]
+              cat['Vz'] = cat['Velocities'][:,2]/np.sqrt(1+z)
               mesh_momen = cat.to_mesh(Nmesh=Nmesh, position='Coordinates', value='Vz')
               pz = mesh_momen.compute()
            L = np.arange(0, Nmesh, 1)


### PR DESCRIPTION
- The displacement of the DM particles was 1/(1+z) of what it was supposed to be.
- The momentum stored on the density output is now corrected by this factor
  So we no longer neeed this correction in fgpa.py